### PR TITLE
Support multiple client IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-passport-google-id-token
+passport-google-id-multi-token
 ========================
 
-[![Build Status](https://travis-ci.org/jmreyes/passport-google-id-token.svg?branch=master)](https://travis-ci.org/jmreyes/passport-google-id-token)
+Identical to [passport-google-id-token](https://github.com/jmreyes/passport-google-id-token), except that you can provide an array of client ID's to check against.
 
 Google ID token authentication strategy for [Passport](http://passportjs.org/) and [Node.js](http://nodejs.org/).
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-passport-google-id-multi-token
+passport-google-id-token
 ========================
 
-Identical to [passport-google-id-token](https://github.com/jmreyes/passport-google-id-token), except that you can provide an array of client ID's to check against.
+[![Build Status](https://travis-ci.org/jmreyes/passport-google-id-token.svg?branch=master)](https://travis-ci.org/jmreyes/passport-google-id-token)
 
 Google ID token authentication strategy for [Passport](http://passportjs.org/) and [Node.js](http://nodejs.org/).
 

--- a/lib/passport-google-id-token/strategy.js
+++ b/lib/passport-google-id-token/strategy.js
@@ -1,7 +1,8 @@
 /**
  * Module dependencies.
  */
-var util = require('util')
+var async = require('async')
+  , util = require('util')
   , Strategy = require('passport-strategy')
   , request = require('request')
   , jwt = require('jsonwebtoken');
@@ -48,7 +49,7 @@ function GoogleTokenStrategy(options, verify) {
 
   this._passReqToCallback = options.passReqToCallback;
 
-  this._clientID = options.clientID;
+  this._clientID = [].concat(options.clientID);
   this._getGoogleCerts = options.getGoogleCerts || getGoogleCerts;
 
   Strategy.call(this);
@@ -104,21 +105,40 @@ GoogleTokenStrategy.prototype.authenticate = function(req, options) {
     return self.fail({ message: "no ID token provided" });
   }
 
-  self._verifyGoogleToken(idToken, self._clientID, self._getGoogleCerts, function(err, parsedToken, info) {
-    if (err) return self.fail({ message: err.message });
+  function verified(err, user, info) {
+    if (err) return self.error(err);
+    if (!user) return self.fail(info);
+    self.success(user, info);
+  }
 
-    if (!parsedToken) return self.fail(info);
+  let errors = [];
 
-    function verified(err, user, info) {
-      if (err) return self.error(err);
-      if (!user) return self.fail(info);
-      self.success(user, info);
-    }
+  // reverse of the usual - keep trying until there's NOT an error
+  async.eachOfSeries(self._clientID, function(item, key, callback) {
+    self._verifyGoogleToken(idToken, self._clientID, self._getGoogleCerts, function(err, parsedToken, info) {
 
-    if (self._passReqToCallback) {
-      self._verify(req, parsedToken, parsedToken.payload.sub, verified);
+      if (err) {
+        errors.push({ message: err.message });
+        return callback(null);
+      }
+
+      if (!parsedToken) {
+        errors.push(info);
+        return callback(null);
+      }
+
+      return callback({ valid: true, passReqToCallback: self._passReqToCallback, parsedToken: parsedToken });
+    });
+  }, function(verification) {
+    if (verification == null) { // it never succeeded
+      if (errors.length === 1) {
+        errors = errors[0];
+      }
+      return self.fail(errors);
+    } else if (verification.passReqToCallback) {
+      self._verify(req, verification.parsedToken, verification.parsedToken.payload.sub, verified);
     } else {
-      self._verify(parsedToken, parsedToken.payload.sub, verified);
+      self._verify(verification.parsedToken, verification.parsedToken.payload.sub, verified);
     }
   });
 }

--- a/package.json
+++ b/package.json
@@ -31,8 +31,9 @@
   ],
   "main": "./lib/passport-google-id-token",
   "dependencies": {
-    "passport-strategy": "^1.0.0",
+    "async": "^2.1.4",
     "jsonwebtoken": "^5.0.0",
+    "passport-strategy": "^1.0.0",
     "request": "2.64.x"
   },
   "devDependencies": {


### PR DESCRIPTION
Can pass in an array (or single ID as string) of IDs, it'll check against all of them before declaring invalid.

Useful for cases where many types of apps / clients are auth'ing against the same server