### PR TITLE
Bump request version to most recent

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "passport-strategy": "^1.0.0",
     "jsonwebtoken": "^5.0.0",
-    "request": "2.68.x"
+    "request": "2.81.x"
   },
   "devDependencies": {
     "mocha": "2.x.x",


### PR DESCRIPTION
Sorry to open another PR for this! I had bumped to the minimum request version that would solve that vulnerability, but there have actually been other vulnerabilities in request and its dependencies since then, for example (https://nodesecurity.io/advisories/130).

I've bumped to the newest version of request since it solves all these issues and still passes tests.