### PR TITLE
Support bearer tokens

### DIFF
--- a/lib/passport-google-id-token/strategy.js
+++ b/lib/passport-google-id-token/strategy.js
@@ -84,6 +84,13 @@ function getGoogleCerts(kid, callback) {
   });
 }
 
+function getBearerToken(headers) {
+  if (headers && headers.authorization) {
+    var parts = headers.authorization.split(' ');
+    return (parts.length === 2 && parts[0] === 'Bearer') ? parts[1] : undefined;
+  }
+}
+
 /**
  * Inherit from `Strategy`.
  */
@@ -101,7 +108,8 @@ GoogleTokenStrategy.prototype.authenticate = function(req, options) {
 
   var idToken = (req.body && (req.body.id_token || req.body.access_token))
     || (req.query && (req.query.id_token || req.query.access_token))
-    || (req.headers && (req.headers.id_token || req.headers.access_token));
+    || (req.headers && (req.headers.id_token || req.headers.access_token))
+    || (getBearerToken(req.headers));
 
   if (!idToken) {
     return self.fail({ message: "no ID token provided" });

--- a/test/strategy.normal.test.js
+++ b/test/strategy.normal.test.js
@@ -83,6 +83,12 @@ describe('Strategy', function() {
     });
   });
 
+  describe('handling a request with bearer token in authorization header', function() {
+    performValidTokenTest(strategy, function(req) {
+      req.headers = { authorization: 'Bearer ' + tokens.valid_token.encoded };
+    });
+  });
+
   describe('handling a valid request with clientID array in strategy options', function() {
     performValidTokenTest(strategyWClientIDArray, function(req) {
       req.body = { access_token : tokens.valid_token.encoded };


### PR DESCRIPTION
I would like to use my access tokens as [bearer tokens](https://tools.ietf.org/html/rfc6750). I guess that's a pretty common thing to do and it's only a small code change, so I hope it can be approved quickly. Thanks.